### PR TITLE
Re-introduce lastIngestedBlock as nextBlockToIngestFrom

### DIFF
--- a/chaindexing-tests/src/tests/events_ingester.rs
+++ b/chaindexing-tests/src/tests/events_ingester.rs
@@ -54,7 +54,7 @@ mod tests {
             let contract_addresses = PostgresRepo::get_all_contract_addresses(&mut conn).await;
             let bayc_contract_address = contract_addresses.first().unwrap();
             assert_eq!(
-                bayc_contract_address.last_ingested_block_number as u32,
+                bayc_contract_address.next_block_number_to_ingest_from as u32,
                 BAYC_CONTRACT_START_BLOCK_NUMBER
             );
             let json_rpc = Arc::new(json_rpc_with_filter_stubber!(
@@ -76,7 +76,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn checkpoints_last_ingested_block_to_the_ingested_block_in_a_given_batch() {
+    pub async fn updates_next_block_number_to_ingest_from_for_a_given_batch() {
         let pool = test_runner::get_pool().await;
 
         test_runner::run_test(&pool, |mut conn| async move {
@@ -98,11 +98,11 @@ mod tests {
             let mut conn = conn.lock().await;
             let contract_addresses = PostgresRepo::get_all_contract_addresses(&mut conn).await;
             let bayc_contract_address = contract_addresses.first().unwrap();
-            let last_ingested_block_number =
-                bayc_contract_address.last_ingested_block_number as u64;
+            let next_block_number_to_ingest_from =
+                bayc_contract_address.next_block_number_to_ingest_from as u64;
             assert_eq!(
-                last_ingested_block_number,
-                BAYC_CONTRACT_START_BLOCK_NUMBER as u64 + blocks_per_batch
+                next_block_number_to_ingest_from,
+                BAYC_CONTRACT_START_BLOCK_NUMBER as u64 + blocks_per_batch + 1
             );
         })
         .await;
@@ -110,7 +110,7 @@ mod tests {
 
     // TODO:
     #[tokio::test]
-    pub async fn continues_from_last_ingested_block_number() {}
+    pub async fn continues_from_next_block_number_to_ingest_from() {}
 
     #[tokio::test]
     pub async fn does_nothing_when_there_are_no_contracts() {

--- a/chaindexing/src/contracts.rs
+++ b/chaindexing/src/contracts.rs
@@ -161,7 +161,7 @@ pub struct UnsavedContractAddress {
     address: String,
     chain_id: i32,
     start_block_number: i64,
-    last_ingested_block_number: i64,
+    next_block_number_to_ingest_from: i64,
     last_handled_block_number: i64,
 }
 
@@ -172,7 +172,7 @@ impl UnsavedContractAddress {
             address: address.to_string(),
             chain_id: *chain as i32,
             start_block_number: start_block_number,
-            last_ingested_block_number: start_block_number,
+            next_block_number_to_ingest_from: start_block_number,
             last_handled_block_number: start_block_number,
         }
     }
@@ -193,7 +193,7 @@ impl ContractAddressID {
 pub struct ContractAddress {
     pub id: i32,
     chain_id: i32,
-    pub last_ingested_block_number: i64,
+    pub next_block_number_to_ingest_from: i64,
     pub last_handled_block_number: i64,
     start_block_number: i64,
     pub address: String,

--- a/chaindexing/src/diesel/schema.rs
+++ b/chaindexing/src/diesel/schema.rs
@@ -4,7 +4,7 @@ diesel::table! {
   chaindexing_contract_addresses (id) {
       id -> Int4,
       chain_id -> Int4,
-      last_ingested_block_number -> Int8,
+      next_block_number_to_ingest_from -> Int8,
       last_handled_block_number -> Int8,
       start_block_number -> Int8,
       address -> Text,

--- a/chaindexing/src/repos/postgres_repo.rs
+++ b/chaindexing/src/repos/postgres_repo.rs
@@ -153,7 +153,7 @@ impl Repo for PostgresRepo {
         chaindexing_events.load(conn).await.unwrap()
     }
 
-    async fn update_last_ingested_block_number<'a>(
+    async fn update_next_block_number_to_ingest_from<'a>(
         conn: &mut Self::Conn<'a>,
         contract_address: &ContractAddress,
         block_number: i64,
@@ -162,7 +162,7 @@ impl Repo for PostgresRepo {
 
         diesel::update(chaindexing_contract_addresses)
             .filter(id.eq(contract_address.id))
-            .set(last_ingested_block_number.eq(block_number))
+            .set(next_block_number_to_ingest_from.eq(block_number))
             .execute(conn)
             .await
             .unwrap();

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -46,7 +46,7 @@ pub trait Repo: Sync + Send + Migratable + Clone {
         from: i64,
     ) -> Box<dyn Stream<Item = Vec<Event>> + Send + Unpin + 'a>;
 
-    async fn update_last_ingested_block_number<'a>(
+    async fn update_next_block_number_to_ingest_from<'a>(
         conn: &mut Self::Conn<'a>,
         contract_address: &ContractAddress,
         block_number: i64,
@@ -100,7 +100,7 @@ impl SQLikeMigrations {
                 contract_name TEXT NOT NULL,
                 chain_id INTEGER NOT NULL,
                 start_block_number BIGINT NOT NULL,
-                last_ingested_block_number BIGINT NULL,
+                next_block_number_to_ingest_from BIGINT NULL,
                 last_handled_block_number BIGINT NULL
         )",
             "CREATE UNIQUE INDEX IF NOT EXISTS chaindexing_contract_addresses_address_index


### PR DESCRIPTION
This improves the mental framework on why we increment the last ingested block number by one when checkpointing at the end of an ingestion batch.