### PR TITLE
Introduce Streamable Repo trait

### DIFF
--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -5,7 +5,7 @@ use futures_util::{stream, StreamExt};
 use tokio::{sync::Mutex, time::interval};
 
 use crate::{contracts::Contracts, events::Event, ChaindexingRepo, Config, Repo};
-use crate::{ChaindexingRepoConn, ContractAddress};
+use crate::{ChaindexingRepoConn, ContractAddress, Streamable};
 
 #[async_trait::async_trait]
 pub trait EventHandler: Send + Sync {
@@ -38,7 +38,7 @@ impl EventHandlers {
         event_handlers_by_event_abi: &HashMap<&str, Arc<dyn EventHandler>>,
     ) {
         let mut contract_addresses_stream =
-            ChaindexingRepo::get_contract_addresses_stream(conn.clone()).await;
+            ChaindexingRepo::get_contract_addresses_stream(conn.clone());
 
         while let Some(contract_addresses) = contract_addresses_stream.next().await {
             stream::iter(contract_addresses)
@@ -66,8 +66,7 @@ impl EventHandlers {
         let mut events_stream = ChaindexingRepo::get_events_stream(
             conn.clone(),
             contract_address.next_block_number_to_handle,
-        )
-        .await;
+        );
 
         while let Some(mut events) = events_stream.next().await {
             events.sort_by_key(|e| (e.block_number, e.log_index));

--- a/chaindexing/src/events_ingester.rs
+++ b/chaindexing/src/events_ingester.rs
@@ -15,7 +15,7 @@ use tokio::time::interval;
 use crate::contracts::Contract;
 use crate::contracts::{ContractEventTopic, Contracts};
 use crate::events::Events;
-use crate::{ChaindexingRepo, ChaindexingRepoConn, Config, ContractAddress, Repo};
+use crate::{ChaindexingRepo, ChaindexingRepoConn, Config, ContractAddress, Repo, Streamable};
 
 #[async_trait::async_trait]
 pub trait EventsIngesterJsonRpc: Clone + Sync + Send {
@@ -98,7 +98,7 @@ impl EventsIngester {
         let current_block_number = (json_rpc.get_block_number().await?).as_u64();
 
         let mut contract_addresses_stream =
-            ChaindexingRepo::get_contract_addresses_stream(conn.clone()).await;
+            ChaindexingRepo::get_contract_addresses_stream(conn.clone());
 
         while let Some(contract_addresses) = contract_addresses_stream.next().await {
             let contract_addresses = Self::filter_uningested_contract_addresses(

--- a/chaindexing/src/repos.rs
+++ b/chaindexing/src/repos.rs
@@ -4,4 +4,4 @@ mod repo;
 pub use postgres_repo::{
     Conn as PostgresRepoConn, Pool as PostgresRepoPool, PostgresRepo, PostgresRepoAsyncConnection,
 };
-pub use repo::{Migratable, Migration, Repo};
+pub use repo::{Migratable, Migration, Repo, Streamable};


### PR DESCRIPTION
The motivation was to explicitly demonstrate that repo data streams should be built synchronously. This removes the unnecessary async decoration enforced by async_trait crate.