### PR TITLE
Fix Chain Reorg Ingestion Bug

### DIFF
--- a/chaindexing/src/chain_reorg.rs
+++ b/chaindexing/src/chain_reorg.rs
@@ -16,10 +16,6 @@ impl MinConfirmationCount {
         Self { value }
     }
 
-    pub fn ideduct_from(&self, block_number: i64, start_block_number: i64) -> u64 {
-        self.deduct_from(block_number as u64, start_block_number as u64)
-    }
-
     pub fn deduct_from(&self, block_number: u64, start_block_number: u64) -> u64 {
         max(start_block_number, block_number - (self.value as u64))
     }

--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -62,7 +62,7 @@ impl Event {
         Self {
             id: uuid::Uuid::new_v4(),
             chain_id: contract_address.chain_id,
-            contract_address: ContractAddress::address_to_string(&log.address),
+            contract_address: ContractAddress::address_to_string(&log.address).to_lowercase(),
             contract_name: contract_address.contract_name.to_owned(),
             abi: event.abi.clone(),
             log_params: serde_json::to_value(log_params).unwrap(),

--- a/chaindexing/src/repos/postgres_repo.rs
+++ b/chaindexing/src/repos/postgres_repo.rs
@@ -124,10 +124,16 @@ impl Repo for PostgresRepo {
 
         chaindexing_events.load(conn).await.unwrap()
     }
-    async fn get_events<'a>(conn: &mut Self::Conn<'a>, from: u64, to: u64) -> Vec<Event> {
+    async fn get_events<'a>(
+        conn: &mut Self::Conn<'a>,
+        address: String,
+        from: u64,
+        to: u64,
+    ) -> Vec<Event> {
         use crate::diesels::schema::chaindexing_events::dsl::*;
 
         chaindexing_events
+            .filter(contract_address.eq(address.to_lowercase()))
             .filter(block_number.between(from as i64, to as i64))
             .load(conn)
             .await

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -47,7 +47,12 @@ pub trait Repo:
 
     async fn create_events<'a>(conn: &mut Self::Conn<'a>, events: &Vec<Event>);
     async fn get_all_events<'a>(conn: &mut Self::Conn<'a>) -> Vec<Event>;
-    async fn get_events<'a>(conn: &mut Self::Conn<'a>, from: u64, to: u64) -> Vec<Event>;
+    async fn get_events<'a>(
+        conn: &mut Self::Conn<'a>,
+        address: String,
+        from: u64,
+        to: u64,
+    ) -> Vec<Event>;
     async fn delete_events_by_ids<'a>(conn: &mut Self::Conn<'a>, ids: &Vec<Uuid>);
 
     async fn update_next_block_number_to_ingest_from<'a>(


### PR DESCRIPTION
Already ingested events should be fetched per contract address to avoid fetching past the range of the given contract address. Equally, the current block number should stay the same in both executions. Instead, the to_block_number should be adjusted for confirmation execution.