### PR TITLE
Fix contract state delete test in CI

### DIFF
--- a/chaindexing-tests/src/lib.rs
+++ b/chaindexing-tests/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod db;
 pub mod factory;
 pub mod test_runner;
-mod tests;
+pub mod tests;

--- a/chaindexing-tests/src/main.rs
+++ b/chaindexing-tests/src/main.rs
@@ -1,5 +1,5 @@
 use chaindexing::{Chaindexing, ChaindexingRepo, HasRawQueryClient, Repo};
-use chaindexing_tests::db;
+use chaindexing_tests::{db, tests};
 
 #[tokio::main]
 async fn main() {
@@ -7,4 +7,6 @@ async fn main() {
     let repo = ChaindexingRepo::new(db::database_url().as_str());
     let raw_query_client = repo.get_raw_query_client().await;
     Chaindexing::run_internal_migrations(&raw_query_client).await;
+
+    tests::setup().await;
 }

--- a/chaindexing-tests/src/tests.rs
+++ b/chaindexing-tests/src/tests.rs
@@ -1,2 +1,6 @@
 mod contract_states;
 mod events_ingester;
+
+pub async fn setup() {
+    contract_states::setup().await;
+}

--- a/chaindexing-tests/src/tests/contract_states.rs
+++ b/chaindexing-tests/src/tests/contract_states.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use chaindexing::{Chaindexing, ChaindexingRepo, EventContext, HasRawQueryClient};
+    use chaindexing::{ChaindexingRepo, EventContext, HasRawQueryClient};
 
     use super::*;
     use crate::factory::{bayc_contract, transfer_event_with_contract};
@@ -9,13 +9,7 @@ mod tests {
     #[tokio::test]
     pub async fn creates_state() {
         let bayc_contract = bayc_contract().add_state_migrations(NftStateMigrations);
-
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
-        Chaindexing::run_migrations_for_contract_states(
-            &raw_query_client,
-            &vec![bayc_contract.clone()],
-        )
-        .await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
         let event_context = EventContext::new(
@@ -40,13 +34,7 @@ mod tests {
     #[tokio::test]
     pub async fn updates_state() {
         let bayc_contract = bayc_contract().add_state_migrations(NftStateMigrations);
-
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
-        Chaindexing::run_migrations_for_contract_states(
-            &raw_query_client,
-            &vec![bayc_contract.clone()],
-        )
-        .await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
         let event_context = EventContext::new(
@@ -77,13 +65,7 @@ mod tests {
     #[tokio::test]
     pub async fn deletes_state() {
         let bayc_contract = bayc_contract().add_state_migrations(NftStateMigrations);
-
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
-        Chaindexing::run_migrations_for_contract_states(
-            &raw_query_client,
-            &vec![bayc_contract.clone()],
-        )
-        .await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
         let event_context = EventContext::new(
@@ -104,8 +86,10 @@ mod tests {
     }
 }
 
-use chaindexing::{ContractState, ContractStateMigrations};
+use chaindexing::{Chaindexing, ContractState, ContractStateMigrations, HasRawQueryClient};
 use serde::{Deserialize, Serialize};
+
+use crate::{factory::bayc_contract, test_runner};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct NftState {
@@ -125,4 +109,10 @@ impl ContractStateMigrations for NftStateMigrations {
     )",
         ]
     }
+}
+
+pub async fn setup() {
+    let bayc_contract = bayc_contract().add_state_migrations(NftStateMigrations);
+    let raw_query_client = test_runner::new_repo().get_raw_query_client().await;
+    Chaindexing::run_migrations_for_contract_states(&raw_query_client, &vec![bayc_contract]).await;
 }


### PR DESCRIPTION
There seems to be a race condition for the contract state
migrations in tests. The commit attempts to fix this
by setting up all migrations for the test suite exactly once.