### PR TITLE
Resiliently interact with JSON RPC

### DIFF
--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -19,9 +19,9 @@ impl Config {
             chains,
             contracts: vec![],
             min_confirmation_count: MinConfirmationCount::new(40),
-            blocks_per_batch: 20,
-            handler_interval_ms: 10000,
-            ingestion_interval_ms: 10000,
+            blocks_per_batch: 10000,
+            handler_interval_ms: 4000,
+            ingestion_interval_ms: 4000,
             reset_count: 0,
         }
     }


### PR DESCRIPTION
This ensures that requests like getting the current block number and fetching the logs must retry till it succeeds for cases where the JsonRpc is temporarily down.